### PR TITLE
Update README.md: cocotb[bus] install option is no longer available

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ simulation:
                 - yum -y --enablerepo=$REPO install libstdc++-static
                 - ln -s /usr/bin/python3 /usr/bin/python
                 - export LC_ALL=C
-                - pip3 install --user git+https://github.com/cocotb/cocotb#egg=cocotb[bus] cocotbext-axi
+                - pip3 install --user cocotb-bus cocotbext-axi
                 - export PATH=/root/.local/bin/:$PATH
                 - export PATH="/opt/cad/mentor/questa/questa-2021.3/questasim/bin:${PATH}"
                 - export MGLS_LICENSE_FILE=/opt/cad/keys/mentor

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project aims to make the simulation of processing elements (PEs) for [TaPaS
 
 Setup simulation:
 ```bash
-pip3 install --user git+https://github.com/cocotb/cocotb#egg=cocotb[bus] cocotbext-axi
+pip3 install --user cocotb-bus cocotbext-axi
 # ensure that cocotb-config is on path
 # build xilinx IP for simulation:
 make simlib_questa


### PR DESCRIPTION
Install via cocotb-bus is recommended instead.
-> See https://github.com/cocotb/cocotb/commit/aa6865a1a672f96ef8cf5dc35ee952b0385ab4fe